### PR TITLE
SEO: per-page metadata, OG tags, sitemap, robots.txt, JSON-LD

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { motion, Variants } from 'framer-motion';
+import { FiArrowRight, FiChevronDown } from 'react-icons/fi';
+import StreamText from './components/StreamText';
+
+const fadeIn: Variants = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1, transition: { duration: 0.4, ease: 'easeOut' } },
+};
+
+const stagger = (delay = 0.18): Variants => ({
+  hidden: {},
+  show: { transition: { staggerChildren: delay } },
+});
+
+// approx ms to stream N words at given speed
+const t = (words: number, speed = 28) => words * speed;
+
+export default function Home() {
+  return (
+    <section className="relative min-h-screen flex flex-col justify-center px-5 sm:px-8 pt-16"
+      style={{
+        backgroundImage: 'radial-gradient(circle, rgba(0,255,136,0.06) 1px, transparent 1px)',
+        backgroundSize: '28px 28px',
+      }}>
+      <div className="absolute bottom-0 left-0 right-0 h-32 pointer-events-none"
+        style={{ background: 'linear-gradient(to bottom, transparent, #0a0a0a)' }} />
+
+      <motion.div className="max-w-6xl mx-auto w-full" variants={stagger()} initial="hidden" animate="show">
+
+        {/* Veteran badge */}
+        <motion.div variants={fadeIn} className="mb-10">
+          <div className="inline-flex items-center gap-2.5 px-4 py-2 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm">
+            <Image src="/64px-Seal_of_the_United_States_Marine_Corps.svg.png" alt="USMC" width={22} height={22} className="opacity-80" />
+            <span className="text-xs font-mono text-gray-400 tracking-widest uppercase">
+              <StreamText speed={55}>Veteran-Owned Business</StreamText>
+            </span>
+          </div>
+        </motion.div>
+
+        {/* Headline */}
+        <motion.h1 variants={fadeIn} className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold leading-[1.05] tracking-tight max-w-4xl">
+          <StreamText speed={55} startDelay={300}>AI Agents &amp; Automation</StreamText>
+          <span className="block" style={{ color: 'var(--accent)' }}>
+            <StreamText speed={55} startDelay={300 + t(4, 55)}>for Small Businesses.</StreamText>
+          </span>
+        </motion.h1>
+
+        {/* Subtext */}
+        <motion.p variants={fadeIn} className="mt-7 text-lg sm:text-xl text-gray-400 max-w-2xl leading-relaxed">
+          <StreamText speed={22} startDelay={600 + t(4, 55)}>
+            How many after-hours calls does your business miss? How many hours does your team spend on tasks a machine could handle? We build the tools that pick up the slack.
+          </StreamText>
+        </motion.p>
+
+        {/* CTAs */}
+        <motion.div variants={fadeIn} className="mt-10 flex flex-wrap gap-4">
+          <Link href="/contact"
+            className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-[#0a0a0a] transition-all hover:scale-105 active:scale-95"
+            style={{ backgroundColor: 'var(--accent)', boxShadow: '0 0 32px rgba(0,255,136,0.25)' }}>
+            Let&apos;s Talk <FiArrowRight />
+          </Link>
+          <Link href="/products"
+            className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-gray-300 bg-white/5 border border-white/10 transition-all hover:bg-white/10 hover:scale-105 active:scale-95">
+            See Our Products
+          </Link>
+        </motion.div>
+
+        {/* Location */}
+        <motion.p variants={fadeIn} className="mt-12 text-xs font-mono text-gray-600 tracking-widest uppercase">
+          <StreamText speed={50} startDelay={2400}>Fort Collins, CO / Serving Colorado &amp; Central Arkansas</StreamText>
+        </motion.p>
+
+      </motion.div>
+
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
+        <FiChevronDown className="text-gray-700" size={22} />
+      </div>
+    </section>
+  );
+}

--- a/app/about/AboutClient.tsx
+++ b/app/about/AboutClient.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import { FiShield } from 'react-icons/fi';
+import StreamText from '../components/StreamText';
+
+const t = (words: number, speed = 28) => words * speed;
+
+const LABEL    = 0;
+const H1       = 300;
+const PARA1    = H1 + t(3, 50) + 100;        // after heading ~950ms
+const PARA2    = PARA1 + t(28, 22) + 200;    // after para1 ~1900ms
+const PARA3    = PARA2 + t(30, 22) + 200;    // after para2 ~2900ms
+
+// Right column staggered alongside left
+const VET_CARD  = H1 + 200;                  // appears alongside heading
+const STATS     = [
+  VET_CARD + t(4, 40) + t(10, 22) + 300,    // ~1800ms
+  VET_CARD + t(4, 40) + t(10, 22) + 600,
+  VET_CARD + t(4, 40) + t(10, 22) + 900,
+  VET_CARD + t(4, 40) + t(10, 22) + 1200,
+];
+
+function appear(delayMs: number) {
+  return {
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
+  };
+}
+
+export default function About() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
+      <div className="max-w-6xl mx-auto">
+
+        <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-14" style={{ color: 'var(--accent)' }}>
+          <StreamText speed={45} startDelay={LABEL}>03 — About</StreamText>
+        </motion.p>
+
+        <div className="grid md:grid-cols-2 gap-12 md:gap-20 items-start">
+
+          {/* Left — text */}
+          <div>
+            <motion.h1 {...appear(H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight mb-8">
+              <StreamText speed={50} startDelay={H1}>About ContraptionSoft</StreamText>
+            </motion.h1>
+            <div className="space-y-5 text-gray-400 leading-relaxed">
+              <motion.p {...appear(PARA1)}>
+                <StreamText speed={22} startDelay={PARA1}>
+                  ContraptionSoft LLC is run by Tyler Malone — software engineer, Marine veteran, and someone who genuinely enjoys figuring out how to make things work better.
+                </StreamText>
+              </motion.p>
+              <motion.p {...appear(PARA2)}>
+                <StreamText speed={22} startDelay={PARA2}>
+                  The focus: get real AI tools into the hands of small businesses that need them but don&apos;t have an IT department to sort it out. Voice agents, automation, custom software — built straight, delivered fast, explained plainly.
+                </StreamText>
+              </motion.p>
+              <motion.p {...appear(PARA3)}>
+                <StreamText speed={30} startDelay={PARA3}>
+                  Based in Fort Collins, CO. Currently working with businesses across Colorado and Central Arkansas.
+                </StreamText>
+              </motion.p>
+            </div>
+          </div>
+
+          {/* Right — veteran card + stats */}
+          <div className="space-y-6">
+            <motion.div {...appear(VET_CARD)} className="flex items-center gap-5 p-6 rounded-2xl border border-white/8 bg-[#111]">
+              <Image
+                src="/64px-Seal_of_the_United_States_Marine_Corps.svg.png"
+                alt="US Marine Corps Seal"
+                width={56}
+                height={56}
+                className="opacity-90 flex-shrink-0"
+              />
+              <div>
+                <div className="flex items-center gap-1.5 mb-1">
+                  <FiShield size={13} style={{ color: 'var(--accent)' }} />
+                  <span className="text-sm font-bold text-white">
+                    <StreamText speed={40} startDelay={VET_CARD + 100}>Veteran-Owned &amp; Operated</StreamText>
+                  </span>
+                </div>
+                <p className="text-sm text-gray-500">
+                  <StreamText speed={22} startDelay={VET_CARD + 500}>
+                    Same reliability, directness, and follow-through — just applied to software.
+                  </StreamText>
+                </p>
+              </div>
+            </motion.div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { val: '100%', label: 'Custom-built' },
+                { val: 'Fast',  label: 'Delivery' },
+                { val: 'No BS', label: 'Communication' },
+                { val: 'Local', label: 'Focus' },
+              ].map(({ val, label }, i) => (
+                <motion.div key={label} {...appear(STATS[i])} className="p-4 rounded-xl border border-white/6 bg-[#111] text-center">
+                  <div className="text-xl font-bold font-mono mb-0.5" style={{ color: 'var(--accent)' }}>
+                    <StreamText speed={55} startDelay={STATS[i] + 80}>{val}</StreamText>
+                  </div>
+                  <div className="text-xs text-gray-600">
+                    <StreamText speed={40} startDelay={STATS[i] + 280}>{label}</StreamText>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,116 +1,30 @@
-'use client';
+import type { Metadata } from 'next';
+import AboutClient from './AboutClient';
 
-import Image from 'next/image';
-import { motion } from 'framer-motion';
-import { FiShield } from 'react-icons/fi';
-import StreamText from '../components/StreamText';
-
-const t = (words: number, speed = 28) => words * speed;
-
-const LABEL    = 0;
-const H1       = 300;
-const PARA1    = H1 + t(3, 50) + 100;        // after heading ~950ms
-const PARA2    = PARA1 + t(28, 22) + 200;    // after para1 ~1900ms
-const PARA3    = PARA2 + t(30, 22) + 200;    // after para2 ~2900ms
-
-// Right column staggered alongside left
-const VET_CARD  = H1 + 200;                  // appears alongside heading
-const STATS     = [
-  VET_CARD + t(4, 40) + t(10, 22) + 300,    // ~1800ms
-  VET_CARD + t(4, 40) + t(10, 22) + 600,
-  VET_CARD + t(4, 40) + t(10, 22) + 900,
-  VET_CARD + t(4, 40) + t(10, 22) + 1200,
-];
-
-function appear(delayMs: number) {
-  return {
-    initial: { opacity: 0, y: 8 },
-    animate: { opacity: 1, y: 0 },
-    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
-  };
-}
+export const metadata: Metadata = {
+  title: 'About | ContraptionSoft LLC',
+  description:
+    'ContraptionSoft LLC is run by Tyler Malone — software engineer, Marine veteran, and someone who gets real AI tools into the hands of small businesses. Fort Collins, CO.',
+  openGraph: {
+    title: 'About | ContraptionSoft LLC',
+    description:
+      'Veteran-owned software company run by Tyler Malone. AI tools built straight, delivered fast, explained plainly. Fort Collins, CO.',
+    url: 'https://contraptionsoft.com/about',
+    siteName: 'ContraptionSoft LLC',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'ContraptionSoft LLC' }],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About | ContraptionSoft LLC',
+    description:
+      'Veteran-owned software company run by Tyler Malone. Fort Collins, CO.',
+    images: ['/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://contraptionsoft.com/about' },
+};
 
 export default function About() {
-  return (
-    <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
-      <div className="max-w-6xl mx-auto">
-
-        <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-14" style={{ color: 'var(--accent)' }}>
-          <StreamText speed={45} startDelay={LABEL}>03 — About</StreamText>
-        </motion.p>
-
-        <div className="grid md:grid-cols-2 gap-12 md:gap-20 items-start">
-
-          {/* Left — text */}
-          <div>
-            <motion.h1 {...appear(H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight mb-8">
-              <StreamText speed={50} startDelay={H1}>About ContraptionSoft</StreamText>
-            </motion.h1>
-            <div className="space-y-5 text-gray-400 leading-relaxed">
-              <motion.p {...appear(PARA1)}>
-                <StreamText speed={22} startDelay={PARA1}>
-                  ContraptionSoft LLC is run by Tyler Malone — software engineer, Marine veteran, and someone who genuinely enjoys figuring out how to make things work better.
-                </StreamText>
-              </motion.p>
-              <motion.p {...appear(PARA2)}>
-                <StreamText speed={22} startDelay={PARA2}>
-                  The focus: get real AI tools into the hands of small businesses that need them but don&apos;t have an IT department to sort it out. Voice agents, automation, custom software — built straight, delivered fast, explained plainly.
-                </StreamText>
-              </motion.p>
-              <motion.p {...appear(PARA3)}>
-                <StreamText speed={30} startDelay={PARA3}>
-                  Based in Fort Collins, CO. Currently working with businesses across Colorado and Central Arkansas.
-                </StreamText>
-              </motion.p>
-            </div>
-          </div>
-
-          {/* Right — veteran card + stats */}
-          <div className="space-y-6">
-            <motion.div {...appear(VET_CARD)} className="flex items-center gap-5 p-6 rounded-2xl border border-white/8 bg-[#111]">
-              <Image
-                src="/64px-Seal_of_the_United_States_Marine_Corps.svg.png"
-                alt="US Marine Corps Seal"
-                width={56}
-                height={56}
-                className="opacity-90 flex-shrink-0"
-              />
-              <div>
-                <div className="flex items-center gap-1.5 mb-1">
-                  <FiShield size={13} style={{ color: 'var(--accent)' }} />
-                  <span className="text-sm font-bold text-white">
-                    <StreamText speed={40} startDelay={VET_CARD + 100}>Veteran-Owned &amp; Operated</StreamText>
-                  </span>
-                </div>
-                <p className="text-sm text-gray-500">
-                  <StreamText speed={22} startDelay={VET_CARD + 500}>
-                    Same reliability, directness, and follow-through — just applied to software.
-                  </StreamText>
-                </p>
-              </div>
-            </motion.div>
-
-            <div className="grid grid-cols-2 gap-3">
-              {[
-                { val: '100%', label: 'Custom-built' },
-                { val: 'Fast',  label: 'Delivery' },
-                { val: 'No BS', label: 'Communication' },
-                { val: 'Local', label: 'Focus' },
-              ].map(({ val, label }, i) => (
-                <motion.div key={label} {...appear(STATS[i])} className="p-4 rounded-xl border border-white/6 bg-[#111] text-center">
-                  <div className="text-xl font-bold font-mono mb-0.5" style={{ color: 'var(--accent)' }}>
-                    <StreamText speed={55} startDelay={STATS[i] + 80}>{val}</StreamText>
-                  </div>
-                  <div className="text-xs text-gray-600">
-                    <StreamText speed={40} startDelay={STATS[i] + 280}>{label}</StreamText>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </div>
-
-        </div>
-      </div>
-    </main>
-  );
+  return <AboutClient />;
 }

--- a/app/contact/ContactClient.tsx
+++ b/app/contact/ContactClient.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { FiArrowRight } from 'react-icons/fi';
+import StreamText from '../components/StreamText';
+
+const t = (words: number, speed = 28) => words * speed;
+
+const LABEL   = 0;
+const H1      = 350;
+const SUB     = H1 + t(5, 48) + 100;        // ~690ms
+const EMAIL   = SUB + t(22, 22) + 200;      // ~1374ms
+const FOOT    = EMAIL + t(1, 30) + 400;     // after email starts ~1804ms
+
+function appear(delayMs: number) {
+  return {
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
+  };
+}
+
+export default function Contact() {
+  return (
+    <main className="min-h-screen bg-[#080808] px-5 sm:px-8 pt-28 pb-24 flex flex-col justify-center">
+      <div className="max-w-6xl mx-auto w-full">
+
+        <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-6" style={{ color: 'var(--accent)' }}>
+          <StreamText speed={45} startDelay={LABEL}>04 — Get in Touch</StreamText>
+        </motion.p>
+
+        <motion.h1 {...appear(H1)} className="text-4xl sm:text-5xl md:text-6xl font-bold text-white leading-tight max-w-2xl mb-6">
+          <StreamText speed={48} startDelay={H1}>Let&apos;s Have a Straight Conversation.</StreamText>
+        </motion.h1>
+
+        <motion.p {...appear(SUB)} className="text-lg text-gray-500 max-w-lg mb-12">
+          <StreamText speed={22} startDelay={SUB}>
+            No sales deck. Tell us what problem you&apos;re dealing with — we&apos;ll tell you honestly if AI can help, and what it would cost.
+          </StreamText>
+        </motion.p>
+
+        <motion.a {...appear(EMAIL)} href="mailto:tyler@contraptionsoft.com" className="group inline-flex items-center gap-3">
+          <span className="text-2xl sm:text-3xl md:text-4xl font-mono font-bold text-white group-hover:underline decoration-[#00ff88] underline-offset-4 transition-all">
+            <StreamText speed={30} startDelay={EMAIL + 80}>tyler@contraptionsoft.com</StreamText>
+          </span>
+          <FiArrowRight size={24} className="text-gray-600 group-hover:text-[#00ff88] group-hover:translate-x-1 transition-all" />
+        </motion.a>
+
+        <motion.p {...appear(FOOT)} className="mt-8 text-sm text-gray-600">
+          <StreamText speed={22} startDelay={FOOT + 80}>
+            Responds within 24 hours. Fort Collins or Central Arkansas (Little Rock, Benton, Hot Springs area)? In-person works too.
+          </StreamText>
+        </motion.p>
+
+      </div>
+    </main>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,58 +1,30 @@
-'use client';
+import type { Metadata } from 'next';
+import ContactClient from './ContactClient';
 
-import { motion } from 'framer-motion';
-import { FiArrowRight } from 'react-icons/fi';
-import StreamText from '../components/StreamText';
-
-const t = (words: number, speed = 28) => words * speed;
-
-const LABEL   = 0;
-const H1      = 350;
-const SUB     = H1 + t(5, 48) + 100;        // ~690ms
-const EMAIL   = SUB + t(22, 22) + 200;      // ~1374ms
-const FOOT    = EMAIL + t(1, 30) + 400;     // after email starts ~1804ms
-
-function appear(delayMs: number) {
-  return {
-    initial: { opacity: 0, y: 8 },
-    animate: { opacity: 1, y: 0 },
-    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
-  };
-}
+export const metadata: Metadata = {
+  title: 'Contact | ContraptionSoft LLC',
+  description:
+    'No sales deck. Tell us what problem you\'re dealing with — we\'ll tell you honestly if AI can help and what it would cost. Fort Collins, CO and Central Arkansas.',
+  openGraph: {
+    title: 'Contact | ContraptionSoft LLC',
+    description:
+      'Get in touch with ContraptionSoft. No sales deck — just a straight conversation about what AI can actually do for your business.',
+    url: 'https://contraptionsoft.com/contact',
+    siteName: 'ContraptionSoft LLC',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'ContraptionSoft LLC' }],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact | ContraptionSoft LLC',
+    description:
+      'Get in touch. No sales deck — just a straight conversation about what AI can do for your business.',
+    images: ['/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://contraptionsoft.com/contact' },
+};
 
 export default function Contact() {
-  return (
-    <main className="min-h-screen bg-[#080808] px-5 sm:px-8 pt-28 pb-24 flex flex-col justify-center">
-      <div className="max-w-6xl mx-auto w-full">
-
-        <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-6" style={{ color: 'var(--accent)' }}>
-          <StreamText speed={45} startDelay={LABEL}>04 — Get in Touch</StreamText>
-        </motion.p>
-
-        <motion.h1 {...appear(H1)} className="text-4xl sm:text-5xl md:text-6xl font-bold text-white leading-tight max-w-2xl mb-6">
-          <StreamText speed={48} startDelay={H1}>Let&apos;s Have a Straight Conversation.</StreamText>
-        </motion.h1>
-
-        <motion.p {...appear(SUB)} className="text-lg text-gray-500 max-w-lg mb-12">
-          <StreamText speed={22} startDelay={SUB}>
-            No sales deck. Tell us what problem you&apos;re dealing with — we&apos;ll tell you honestly if AI can help, and what it would cost.
-          </StreamText>
-        </motion.p>
-
-        <motion.a {...appear(EMAIL)} href="mailto:tyler@contraptionsoft.com" className="group inline-flex items-center gap-3">
-          <span className="text-2xl sm:text-3xl md:text-4xl font-mono font-bold text-white group-hover:underline decoration-[#00ff88] underline-offset-4 transition-all">
-            <StreamText speed={30} startDelay={EMAIL + 80}>tyler@contraptionsoft.com</StreamText>
-          </span>
-          <FiArrowRight size={24} className="text-gray-600 group-hover:text-[#00ff88] group-hover:translate-x-1 transition-all" />
-        </motion.a>
-
-        <motion.p {...appear(FOOT)} className="mt-8 text-sm text-gray-600">
-          <StreamText speed={22} startDelay={FOOT + 80}>
-            Responds within 24 hours. Fort Collins or Central Arkansas (Little Rock, Benton, Hot Springs area)? In-person works too.
-          </StreamText>
-        </motion.p>
-
-      </div>
-    </main>
-  );
+  return <ContactClient />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import Nav from "./components/Nav";
 import Footer from "./components/Footer";
@@ -68,6 +69,13 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0a0a0a]`}>
+        <Script src="https://www.googletagmanager.com/gtag/js?id=G-BPN4T8ZBY3" strategy="afterInteractive" />
+        <Script id="gtag-init" strategy="afterInteractive">{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-BPN4T8ZBY3');
+        `}</Script>
         <Nav />
         {children}
         <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,43 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "ContraptionSoft LLC | AI Agents & Automation for Small Businesses",
-  description: "AI voice agents, morning briefings, and intelligent automation for small businesses. Veteran-owned. Based in Fort Collins, CO.",
+  metadataBase: new URL('https://contraptionsoft.com'),
+  title: {
+    default: 'ContraptionSoft LLC | AI Agents & Automation for Small Businesses',
+    template: '%s | ContraptionSoft LLC',
+  },
+  description:
+    'AI voice agents, workflow automation, and custom software for small businesses. Veteran-owned. Based in Fort Collins, CO — serving Colorado and Central Arkansas.',
+  keywords: [
+    'AI agents', 'small business automation', 'voice agent', 'AI automation',
+    'Fort Collins', 'Colorado', 'Arkansas', 'veteran owned business',
+    'workflow automation', 'custom software',
+  ],
+  authors: [{ name: 'Tyler Malone', url: 'https://contraptionsoft.com' }],
+  creator: 'ContraptionSoft LLC',
+  robots: { index: true, follow: true },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'ContraptionSoft LLC',
+  description:
+    'AI voice agents, workflow automation, and custom software for small businesses. Veteran-owned.',
+  url: 'https://contraptionsoft.com',
+  email: 'tyler@contraptionsoft.com',
+  founder: { '@type': 'Person', name: 'Tyler Malone' },
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Fort Collins',
+    addressRegion: 'CO',
+    addressCountry: 'US',
+  },
+  areaServed: [
+    { '@type': 'State', name: 'Colorado' },
+    { '@type': 'State', name: 'Arkansas' },
+  ],
+  knowsAbout: ['AI agents', 'workflow automation', 'voice agents', 'custom software', 'small business technology'],
 };
 
 export default function RootLayout({
@@ -26,6 +61,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="bg-[#0a0a0a]">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0a0a0a]`}>
         <Nav />
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,84 +1,30 @@
-'use client';
+import type { Metadata } from 'next';
+import HomeClient from './HomeClient';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { motion, Variants } from 'framer-motion';
-import { FiArrowRight, FiChevronDown } from 'react-icons/fi';
-import StreamText from './components/StreamText';
-
-const fadeIn: Variants = {
-  hidden: { opacity: 0 },
-  show: { opacity: 1, transition: { duration: 0.4, ease: 'easeOut' } },
+export const metadata: Metadata = {
+  title: 'ContraptionSoft LLC | AI Agents & Automation for Small Businesses',
+  description:
+    'AI voice agents, workflow automation, and custom software for small businesses. Veteran-owned. Based in Fort Collins, CO — serving Colorado and Central Arkansas.',
+  openGraph: {
+    title: 'ContraptionSoft LLC | AI Agents & Automation for Small Businesses',
+    description:
+      'AI voice agents, workflow automation, and custom software for small businesses. Veteran-owned. Fort Collins, CO.',
+    url: 'https://contraptionsoft.com',
+    siteName: 'ContraptionSoft LLC',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'ContraptionSoft LLC' }],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'ContraptionSoft LLC | AI Agents & Automation for Small Businesses',
+    description:
+      'AI voice agents, workflow automation, and custom software for small businesses. Veteran-owned. Fort Collins, CO.',
+    images: ['/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://contraptionsoft.com' },
 };
 
-const stagger = (delay = 0.18): Variants => ({
-  hidden: {},
-  show: { transition: { staggerChildren: delay } },
-});
-
-// approx ms to stream N words at given speed
-const t = (words: number, speed = 28) => words * speed;
-
 export default function Home() {
-  return (
-    <section className="relative min-h-screen flex flex-col justify-center px-5 sm:px-8 pt-16"
-      style={{
-        backgroundImage: 'radial-gradient(circle, rgba(0,255,136,0.06) 1px, transparent 1px)',
-        backgroundSize: '28px 28px',
-      }}>
-      <div className="absolute bottom-0 left-0 right-0 h-32 pointer-events-none"
-        style={{ background: 'linear-gradient(to bottom, transparent, #0a0a0a)' }} />
-
-      <motion.div className="max-w-6xl mx-auto w-full" variants={stagger()} initial="hidden" animate="show">
-
-        {/* Veteran badge */}
-        <motion.div variants={fadeIn} className="mb-10">
-          <div className="inline-flex items-center gap-2.5 px-4 py-2 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm">
-            <Image src="/64px-Seal_of_the_United_States_Marine_Corps.svg.png" alt="USMC" width={22} height={22} className="opacity-80" />
-            <span className="text-xs font-mono text-gray-400 tracking-widest uppercase">
-              <StreamText speed={55}>Veteran-Owned Business</StreamText>
-            </span>
-          </div>
-        </motion.div>
-
-        {/* Headline */}
-        <motion.h1 variants={fadeIn} className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold leading-[1.05] tracking-tight max-w-4xl">
-          <StreamText speed={55} startDelay={300}>AI Agents &amp; Automation</StreamText>
-          <span className="block" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={55} startDelay={300 + t(4, 55)}>for Small Businesses.</StreamText>
-          </span>
-        </motion.h1>
-
-        {/* Subtext */}
-        <motion.p variants={fadeIn} className="mt-7 text-lg sm:text-xl text-gray-400 max-w-2xl leading-relaxed">
-          <StreamText speed={22} startDelay={600 + t(4, 55)}>
-            How many after-hours calls does your business miss? How many hours does your team spend on tasks a machine could handle? We build the tools that pick up the slack.
-          </StreamText>
-        </motion.p>
-
-        {/* CTAs */}
-        <motion.div variants={fadeIn} className="mt-10 flex flex-wrap gap-4">
-          <Link href="/contact"
-            className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-[#0a0a0a] transition-all hover:scale-105 active:scale-95"
-            style={{ backgroundColor: 'var(--accent)', boxShadow: '0 0 32px rgba(0,255,136,0.25)' }}>
-            Let&apos;s Talk <FiArrowRight />
-          </Link>
-          <Link href="/products"
-            className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-gray-300 bg-white/5 border border-white/10 transition-all hover:bg-white/10 hover:scale-105 active:scale-95">
-            See Our Products
-          </Link>
-        </motion.div>
-
-        {/* Location */}
-        <motion.p variants={fadeIn} className="mt-12 text-xs font-mono text-gray-600 tracking-widest uppercase">
-          <StreamText speed={50} startDelay={2400}>Fort Collins, CO / Serving Colorado &amp; Central Arkansas</StreamText>
-        </motion.p>
-
-      </motion.div>
-
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
-        <FiChevronDown className="text-gray-700" size={22} />
-      </div>
-    </section>
-  );
+  return <HomeClient />;
 }

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { FiMic, FiTerminal, FiDatabase, FiZap, FiGlobe, FiCheck, FiArrowRight } from 'react-icons/fi';
+import StreamText from '../components/StreamText';
+
+// ms to stream N words at a given speed
+const t = (words: number, speed = 28) => words * speed;
+
+// Timings — each element appears, then its text immediately starts streaming
+const HEADER_LABEL   = 0;
+const HEADER_H1      = 400;
+const HEADER_SUB     = 900;
+const HEADER_DONE    = HEADER_SUB + t(18, 22); // ~1300ms
+
+const CARD_1         = HEADER_DONE + 200;       // ~1500ms
+const CARD_2         = CARD_1 + 900;            // ~2400ms
+const CARD_3         = CARD_2 + 900;            // ~3300ms
+
+const COMP_1         = CARD_3 + 1100;           // ~4400ms
+const COMP_2         = COMP_1 + 1400;           // ~5800ms
+
+// Per-card list item delays relative to card appearance
+const ITEM_OFFSET = (descWords: number, descSpeed = 22) =>
+  t(2, 50) + 100 + t(descWords, descSpeed);
+
+function appear(delayMs: number) {
+  return {
+    initial: { opacity: 0, y: 6 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay: delayMs / 1000, duration: 0.35, ease: 'easeOut' as const },
+  };
+}
+
+export default function Products() {
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
+      <div className="max-w-6xl mx-auto">
+
+        {/* Section header — streams first */}
+        <div className="mb-14">
+          <motion.p {...appear(HEADER_LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
+            <StreamText speed={45} startDelay={HEADER_LABEL}>01 — What We Build</StreamText>
+          </motion.p>
+          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight max-w-xl">
+            <StreamText speed={50} startDelay={HEADER_H1}>AI Tools Built for the Real World</StreamText>
+          </motion.h1>
+          <motion.p {...appear(HEADER_SUB)} className="mt-4 text-gray-500 max-w-xl">
+            <StreamText speed={22} startDelay={HEADER_SUB}>
+              Not vaporware. Not demos. Deployed tools that run your business while you&apos;re busy running your business.
+            </StreamText>
+          </motion.p>
+        </div>
+
+        {/* Product cards — appear one at a time */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+
+          {[
+            {
+              icon: <FiMic className="text-[#0a0a0a]" size={18} />,
+              title: 'Voice Agent',
+              desc: 'An AI that answers your phone after hours, books appointments, handles FAQs, and routes urgent calls. No lead goes cold.',
+              items: ['Answers calls 24/7', 'Books appointments automatically', 'Handles common questions', 'Escalates urgent issues to you'],
+              appear: CARD_1,
+            },
+            {
+              icon: <FiTerminal className="text-[#0a0a0a]" size={18} />,
+              title: 'AI Agents',
+              desc: 'Always-on AI you reach through your messaging app. Morning briefing, web deploy, research — just ask.',
+              items: ['Discord, Slack, or SMS', 'Builds and deploys web projects', 'Runs 24/7'],
+              appear: CARD_2,
+            },
+            {
+              icon: <FiDatabase className="text-[#0a0a0a]" size={18} />,
+              title: 'Local File Search',
+              desc: 'Ask a question, get an answer from your own documents. No cloud upload. Your data stays put.',
+              items: ['PDFs, Word, spreadsheets', 'No cloud required', 'Private by design'],
+              appear: CARD_3,
+            },
+          ].map(({ icon, title, desc, items, appear: cardAt }) => {
+            const textAt   = cardAt + 80;
+            const descAt   = textAt + t(title.split(' ').length, 50) + 100;
+            const itemBase = descAt + t(desc.split(' ').length, 22) + 150;
+            return (
+              <motion.div
+                key={title}
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: cardAt / 1000, duration: 0.4, ease: 'easeOut' }}
+                className="p-6 sm:p-7 rounded-2xl border border-white/8 bg-[#111] hover:border-white/15 hover:scale-[1.02] transition-colors group cursor-default"
+              >
+                <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform"
+                  style={{ backgroundColor: 'var(--accent)' }}>
+                  {icon}
+                </div>
+                <h2 className="text-xl font-bold text-white mb-2 font-mono">
+                  <StreamText speed={50} startDelay={textAt}>{title}</StreamText>
+                </h2>
+                <p className="text-sm text-gray-500 leading-relaxed mb-5">
+                  <StreamText speed={22} startDelay={descAt}>{desc}</StreamText>
+                </p>
+                <ul className="space-y-2">
+                  {items.map((item, i) => (
+                    <li key={item} className="flex items-center gap-2 text-xs text-gray-400">
+                      <FiCheck size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+                      <StreamText speed={32} startDelay={itemBase + i * 260}>{item}</StreamText>
+                    </li>
+                  ))}
+                </ul>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        {/* Comparison blocks — appear after cards */}
+        <div className="mt-4 space-y-3">
+          {[
+            {
+              icon: <FiZap size={14} />,
+              topic: 'Workflow Automation',
+              before: ['Pick a tool (Zapier, Make, n8n…)', 'Configure triggers and steps', 'Debug it when something breaks', 'Start over for every new workflow'],
+              after: ['"Send me a summary every Monday"', '"Flag any invoice over $500"', '"Follow up if no reply in 2 days"', 'Just say it. Agent handles the rest.'],
+              appear: COMP_1,
+            },
+            {
+              icon: <FiGlobe size={14} />,
+              topic: 'Web Presence',
+              before: ['Find and vet a web developer', 'Wait days for a response', 'Pay for every small change', 'Hope they understood what you wanted'],
+              after: ["Chat with it anytime — it doesn't sleep", 'It codes, ships, and handles SEO', 'Changes happen in minutes', 'No queue. No invoice. No delay.'],
+              appear: COMP_2,
+            },
+          ].map(({ icon, topic, before, after, appear: blockAt }) => (
+            <motion.div
+              key={topic}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: blockAt / 1000, duration: 0.4, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/8 overflow-hidden"
+              style={{ background: '#0d0d0d' }}
+            >
+              <div className="px-6 py-3 border-b border-white/8 flex items-center gap-2">
+                <span className="text-gray-500">{icon}</span>
+                <span className="text-xs font-mono text-gray-400 uppercase tracking-widest">
+                  <StreamText speed={40} startDelay={blockAt + 80}>{topic}</StreamText>
+                </span>
+              </div>
+              <div className="flex flex-col sm:flex-row">
+                <div className="flex-1 p-6 sm:p-7">
+                  <p className="text-xs font-mono text-gray-600 uppercase tracking-widest mb-4">Without an agent</p>
+                  <ul className="space-y-3">
+                    {before.map((item, i) => (
+                      <li key={item} className="flex items-start gap-3 text-sm text-gray-600">
+                        <span className="mt-1 text-gray-700 flex-shrink-0 font-mono">—</span>
+                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="hidden sm:flex items-center justify-center px-2">
+                  <div className="flex flex-col items-center gap-1">
+                    <div className="w-px h-8 bg-white/10" />
+                    <FiArrowRight size={16} style={{ color: 'var(--accent)' }} />
+                    <div className="w-px h-8 bg-white/10" />
+                  </div>
+                </div>
+                <div className="sm:hidden flex items-center justify-center py-2 border-t border-white/8">
+                  <FiArrowRight size={16} className="rotate-90" style={{ color: 'var(--accent)' }} />
+                </div>
+                <div className="flex-1 p-6 sm:p-7 border-t sm:border-t-0 sm:border-l border-white/8" style={{ background: 'rgba(0,255,136,0.03)' }}>
+                  <p className="text-xs font-mono uppercase tracking-widest mb-4" style={{ color: 'var(--accent)' }}>With an agent</p>
+                  <ul className="space-y-3">
+                    {after.map((item, i) => (
+                      <li key={item} className="flex items-start gap-3 text-sm text-gray-200">
+                        <FiCheck size={13} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 3 }} />
+                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+      </div>
+    </main>
+  );
+}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,188 +1,30 @@
-'use client';
+import type { Metadata } from 'next';
+import ProductsClient from './ProductsClient';
 
-import { motion } from 'framer-motion';
-import { FiMic, FiTerminal, FiDatabase, FiZap, FiGlobe, FiCheck, FiArrowRight } from 'react-icons/fi';
-import StreamText from '../components/StreamText';
-
-// ms to stream N words at a given speed
-const t = (words: number, speed = 28) => words * speed;
-
-// Timings — each element appears, then its text immediately starts streaming
-const HEADER_LABEL   = 0;
-const HEADER_H1      = 400;
-const HEADER_SUB     = 900;
-const HEADER_DONE    = HEADER_SUB + t(18, 22); // ~1300ms
-
-const CARD_1         = HEADER_DONE + 200;       // ~1500ms
-const CARD_2         = CARD_1 + 900;            // ~2400ms
-const CARD_3         = CARD_2 + 900;            // ~3300ms
-
-const COMP_1         = CARD_3 + 1100;           // ~4400ms
-const COMP_2         = COMP_1 + 1400;           // ~5800ms
-
-// Per-card list item delays relative to card appearance
-const ITEM_OFFSET = (descWords: number, descSpeed = 22) =>
-  t(2, 50) + 100 + t(descWords, descSpeed);
-
-function appear(delayMs: number) {
-  return {
-    initial: { opacity: 0, y: 6 },
-    animate: { opacity: 1, y: 0 },
-    transition: { delay: delayMs / 1000, duration: 0.35, ease: 'easeOut' as const },
-  };
-}
+export const metadata: Metadata = {
+  title: 'AI Products | ContraptionSoft LLC',
+  description:
+    'Voice agents that answer your phone 24/7, AI agents for workflow automation, and local file search — tools built for small businesses that need results, not demos.',
+  openGraph: {
+    title: 'AI Products | ContraptionSoft LLC',
+    description:
+      'Voice agents, AI automation, and local file search for small businesses. No vaporware. Deployed tools that run your business.',
+    url: 'https://contraptionsoft.com/products',
+    siteName: 'ContraptionSoft LLC',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'ContraptionSoft LLC' }],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AI Products | ContraptionSoft LLC',
+    description:
+      'Voice agents, AI automation, and local file search for small businesses.',
+    images: ['/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://contraptionsoft.com/products' },
+};
 
 export default function Products() {
-  return (
-    <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
-      <div className="max-w-6xl mx-auto">
-
-        {/* Section header — streams first */}
-        <div className="mb-14">
-          <motion.p {...appear(HEADER_LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={45} startDelay={HEADER_LABEL}>01 — What We Build</StreamText>
-          </motion.p>
-          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight max-w-xl">
-            <StreamText speed={50} startDelay={HEADER_H1}>AI Tools Built for the Real World</StreamText>
-          </motion.h1>
-          <motion.p {...appear(HEADER_SUB)} className="mt-4 text-gray-500 max-w-xl">
-            <StreamText speed={22} startDelay={HEADER_SUB}>
-              Not vaporware. Not demos. Deployed tools that run your business while you&apos;re busy running your business.
-            </StreamText>
-          </motion.p>
-        </div>
-
-        {/* Product cards — appear one at a time */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-
-          {[
-            {
-              icon: <FiMic className="text-[#0a0a0a]" size={18} />,
-              title: 'Voice Agent',
-              desc: 'An AI that answers your phone after hours, books appointments, handles FAQs, and routes urgent calls. No lead goes cold.',
-              items: ['Answers calls 24/7', 'Books appointments automatically', 'Handles common questions', 'Escalates urgent issues to you'],
-              appear: CARD_1,
-            },
-            {
-              icon: <FiTerminal className="text-[#0a0a0a]" size={18} />,
-              title: 'AI Agents',
-              desc: 'Always-on AI you reach through your messaging app. Morning briefing, web deploy, research — just ask.',
-              items: ['Discord, Slack, or SMS', 'Builds and deploys web projects', 'Runs 24/7'],
-              appear: CARD_2,
-            },
-            {
-              icon: <FiDatabase className="text-[#0a0a0a]" size={18} />,
-              title: 'Local File Search',
-              desc: 'Ask a question, get an answer from your own documents. No cloud upload. Your data stays put.',
-              items: ['PDFs, Word, spreadsheets', 'No cloud required', 'Private by design'],
-              appear: CARD_3,
-            },
-          ].map(({ icon, title, desc, items, appear: cardAt }) => {
-            const textAt   = cardAt + 80;
-            const descAt   = textAt + t(title.split(' ').length, 50) + 100;
-            const itemBase = descAt + t(desc.split(' ').length, 22) + 150;
-            return (
-              <motion.div
-                key={title}
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: cardAt / 1000, duration: 0.4, ease: 'easeOut' }}
-                className="p-6 sm:p-7 rounded-2xl border border-white/8 bg-[#111] hover:border-white/15 hover:scale-[1.02] transition-colors group cursor-default"
-              >
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform"
-                  style={{ backgroundColor: 'var(--accent)' }}>
-                  {icon}
-                </div>
-                <h2 className="text-xl font-bold text-white mb-2 font-mono">
-                  <StreamText speed={50} startDelay={textAt}>{title}</StreamText>
-                </h2>
-                <p className="text-sm text-gray-500 leading-relaxed mb-5">
-                  <StreamText speed={22} startDelay={descAt}>{desc}</StreamText>
-                </p>
-                <ul className="space-y-2">
-                  {items.map((item, i) => (
-                    <li key={item} className="flex items-center gap-2 text-xs text-gray-400">
-                      <FiCheck size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />
-                      <StreamText speed={32} startDelay={itemBase + i * 260}>{item}</StreamText>
-                    </li>
-                  ))}
-                </ul>
-              </motion.div>
-            );
-          })}
-        </div>
-
-        {/* Comparison blocks — appear after cards */}
-        <div className="mt-4 space-y-3">
-          {[
-            {
-              icon: <FiZap size={14} />,
-              topic: 'Workflow Automation',
-              before: ['Pick a tool (Zapier, Make, n8n…)', 'Configure triggers and steps', 'Debug it when something breaks', 'Start over for every new workflow'],
-              after: ['"Send me a summary every Monday"', '"Flag any invoice over $500"', '"Follow up if no reply in 2 days"', 'Just say it. Agent handles the rest.'],
-              appear: COMP_1,
-            },
-            {
-              icon: <FiGlobe size={14} />,
-              topic: 'Web Presence',
-              before: ['Find and vet a web developer', 'Wait days for a response', 'Pay for every small change', 'Hope they understood what you wanted'],
-              after: ["Chat with it anytime — it doesn't sleep", 'It codes, ships, and handles SEO', 'Changes happen in minutes', 'No queue. No invoice. No delay.'],
-              appear: COMP_2,
-            },
-          ].map(({ icon, topic, before, after, appear: blockAt }) => (
-            <motion.div
-              key={topic}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: blockAt / 1000, duration: 0.4, ease: 'easeOut' }}
-              className="rounded-2xl border border-white/8 overflow-hidden"
-              style={{ background: '#0d0d0d' }}
-            >
-              <div className="px-6 py-3 border-b border-white/8 flex items-center gap-2">
-                <span className="text-gray-500">{icon}</span>
-                <span className="text-xs font-mono text-gray-400 uppercase tracking-widest">
-                  <StreamText speed={40} startDelay={blockAt + 80}>{topic}</StreamText>
-                </span>
-              </div>
-              <div className="flex flex-col sm:flex-row">
-                <div className="flex-1 p-6 sm:p-7">
-                  <p className="text-xs font-mono text-gray-600 uppercase tracking-widest mb-4">Without an agent</p>
-                  <ul className="space-y-3">
-                    {before.map((item, i) => (
-                      <li key={item} className="flex items-start gap-3 text-sm text-gray-600">
-                        <span className="mt-1 text-gray-700 flex-shrink-0 font-mono">—</span>
-                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="hidden sm:flex items-center justify-center px-2">
-                  <div className="flex flex-col items-center gap-1">
-                    <div className="w-px h-8 bg-white/10" />
-                    <FiArrowRight size={16} style={{ color: 'var(--accent)' }} />
-                    <div className="w-px h-8 bg-white/10" />
-                  </div>
-                </div>
-                <div className="sm:hidden flex items-center justify-center py-2 border-t border-white/8">
-                  <FiArrowRight size={16} className="rotate-90" style={{ color: 'var(--accent)' }} />
-                </div>
-                <div className="flex-1 p-6 sm:p-7 border-t sm:border-t-0 sm:border-l border-white/8" style={{ background: 'rgba(0,255,136,0.03)' }}>
-                  <p className="text-xs font-mono uppercase tracking-widest mb-4" style={{ color: 'var(--accent)' }}>With an agent</p>
-                  <ul className="space-y-3">
-                    {after.map((item, i) => (
-                      <li key={item} className="flex items-start gap-3 text-sm text-gray-200">
-                        <FiCheck size={13} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 3 }} />
-                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-
-      </div>
-    </main>
-  );
+  return <ProductsClient />;
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://contraptionsoft.com/sitemap.xml',
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = 'https://contraptionsoft.com';
+  return [
+    { url: base,               lastModified: new Date(), changeFrequency: 'monthly', priority: 1 },
+    { url: `${base}/products`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${base}/work`,     lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${base}/about`,    lastModified: new Date(), changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${base}/contact`,  lastModified: new Date(), changeFrequency: 'yearly',  priority: 0.6 },
+  ];
+}

--- a/app/work/WorkClient.tsx
+++ b/app/work/WorkClient.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { FiGlobe, FiArrowRight } from 'react-icons/fi';
+import StreamText from '../components/StreamText';
+
+const t = (words: number, speed = 28) => words * speed;
+
+const LABEL      = 0;
+const H1         = 350;
+const SUB        = 700;
+const HEADER_DONE = SUB + t(5, 28) + 100;   // ~940ms
+
+const CASE_CARD  = HEADER_DONE + 200;        // ~1140ms
+const YOUR_CARD  = CASE_CARD + 1400;         // ~2540ms — after Malone card text is rolling
+
+function appear(delayMs: number) {
+  return {
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
+  };
+}
+
+export default function Work() {
+  return (
+    <main className="min-h-screen bg-[#080808] px-5 sm:px-8 pt-28 pb-24">
+      <div className="max-w-6xl mx-auto">
+
+        {/* Header */}
+        <div className="mb-14">
+          <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
+            <StreamText speed={45} startDelay={LABEL}>02 — Our Work</StreamText>
+          </motion.p>
+          <motion.h1 {...appear(H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight">
+            <StreamText speed={55} startDelay={H1}>Work That Ships</StreamText>
+          </motion.h1>
+          <motion.p {...appear(SUB)} className="mt-4 text-gray-500 max-w-xl">
+            <StreamText speed={35} startDelay={SUB}>Real projects, real outcomes.</StreamText>
+          </motion.p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4">
+
+          {/* Malone Septic case study */}
+          <motion.div
+            {...appear(CASE_CARD)}
+            className="p-8 sm:p-10 rounded-2xl flex flex-col justify-between"
+            style={{
+              background: 'linear-gradient(150deg, #0c1c10 0%, #0a0a0a 100%)',
+              border: '1px solid rgba(0,255,136,0.25)',
+              boxShadow: '0 0 60px rgba(0,255,136,0.05)',
+            }}>
+            <div>
+              <div className="flex items-center gap-3 mb-5">
+                <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
+                  style={{ backgroundColor: 'var(--accent)' }}>
+                  <FiGlobe className="text-[#0a0a0a]" size={16} />
+                </div>
+                <p className="text-xs font-mono uppercase tracking-widest text-gray-500">
+                  <StreamText speed={40} startDelay={CASE_CARD + 100}>Case Study</StreamText>
+                </p>
+              </div>
+              <h2 className="text-2xl sm:text-3xl font-bold text-white mb-5">
+                <StreamText speed={45} startDelay={CASE_CARD + 350}>Malone Septic &amp; Excavation</StreamText>
+              </h2>
+              <p className="text-gray-400 leading-relaxed">
+                <StreamText speed={20} startDelay={CASE_CARD + 700}>
+                  A local excavation company had no web presence at all. We built and launched a full site — branding, copy, contact forms, SEO — in one week. Now they show up when customers search, and leads come in while the owner is on the job.
+                </StreamText>
+              </p>
+            </div>
+            <div className="grid grid-cols-3 gap-6 mt-8">
+              {[
+                { stat: '0 → Live', label: 'Web Presence',      delay: CASE_CARD + 2600 },
+                { stat: '1 Week',   label: 'Start to Launch',   delay: CASE_CARD + 2900 },
+                { stat: 'Organic',  label: 'Leads from Search', delay: CASE_CARD + 3200 },
+              ].map(({ stat, label, delay }) => (
+                <motion.div key={label} {...appear(delay)}>
+                  <div className="text-2xl font-bold font-mono" style={{ color: 'var(--accent)' }}>
+                    <StreamText speed={55} startDelay={delay + 80}>{stat}</StreamText>
+                  </div>
+                  <div className="text-xs text-gray-600 mt-1">
+                    <StreamText speed={40} startDelay={delay + 280}>{label}</StreamText>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+
+          {/* Your business here */}
+          <motion.div
+            {...appear(YOUR_CARD)}
+            className="p-8 sm:p-10 rounded-2xl border border-dashed border-white/10 flex flex-col items-start justify-between gap-8"
+            style={{ background: '#0d0d0d' }}>
+            <div>
+              <h2 className="text-xl font-bold text-gray-300 mb-3">
+                <StreamText speed={50} startDelay={YOUR_CARD + 80}>Your Business Here</StreamText>
+              </h2>
+              <p className="text-gray-500 leading-relaxed text-sm">
+                <StreamText speed={22} startDelay={YOUR_CARD + 380}>
+                  Working with small businesses in Arkansas and Colorado right now. If you&apos;re curious what AI could actually do for your operation — let&apos;s have a straight conversation.
+                </StreamText>
+              </p>
+            </div>
+            <Link href="/contact"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm transition-all hover:scale-105"
+              style={{ backgroundColor: 'var(--accent)', color: '#0a0a0a' }}>
+              Get in Touch <FiArrowRight size={14} />
+            </Link>
+          </motion.div>
+
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,118 +1,30 @@
-'use client';
+import type { Metadata } from 'next';
+import WorkClient from './WorkClient';
 
-import Link from 'next/link';
-import { motion } from 'framer-motion';
-import { FiGlobe, FiArrowRight } from 'react-icons/fi';
-import StreamText from '../components/StreamText';
-
-const t = (words: number, speed = 28) => words * speed;
-
-const LABEL      = 0;
-const H1         = 350;
-const SUB        = 700;
-const HEADER_DONE = SUB + t(5, 28) + 100;   // ~940ms
-
-const CASE_CARD  = HEADER_DONE + 200;        // ~1140ms
-const YOUR_CARD  = CASE_CARD + 1400;         // ~2540ms — after Malone card text is rolling
-
-function appear(delayMs: number) {
-  return {
-    initial: { opacity: 0, y: 8 },
-    animate: { opacity: 1, y: 0 },
-    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
-  };
-}
+export const metadata: Metadata = {
+  title: 'Our Work | ContraptionSoft LLC',
+  description:
+    'Real projects, real outcomes. See how ContraptionSoft built and launched a full website for Malone Septic & Excavation in one week — branding, SEO, and lead generation included.',
+  openGraph: {
+    title: 'Our Work | ContraptionSoft LLC',
+    description:
+      'Real projects, real outcomes. Full website launch for a local excavation company in one week — from zero web presence to ranking in search.',
+    url: 'https://contraptionsoft.com/work',
+    siteName: 'ContraptionSoft LLC',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: 'ContraptionSoft LLC' }],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Our Work | ContraptionSoft LLC',
+    description:
+      'Real projects, real outcomes. Full website launch for a local excavation company in one week.',
+    images: ['/og-image.jpg'],
+  },
+  alternates: { canonical: 'https://contraptionsoft.com/work' },
+};
 
 export default function Work() {
-  return (
-    <main className="min-h-screen bg-[#080808] px-5 sm:px-8 pt-28 pb-24">
-      <div className="max-w-6xl mx-auto">
-
-        {/* Header */}
-        <div className="mb-14">
-          <motion.p {...appear(LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={45} startDelay={LABEL}>02 — Our Work</StreamText>
-          </motion.p>
-          <motion.h1 {...appear(H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight">
-            <StreamText speed={55} startDelay={H1}>Work That Ships</StreamText>
-          </motion.h1>
-          <motion.p {...appear(SUB)} className="mt-4 text-gray-500 max-w-xl">
-            <StreamText speed={35} startDelay={SUB}>Real projects, real outcomes.</StreamText>
-          </motion.p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-4">
-
-          {/* Malone Septic case study */}
-          <motion.div
-            {...appear(CASE_CARD)}
-            className="p-8 sm:p-10 rounded-2xl flex flex-col justify-between"
-            style={{
-              background: 'linear-gradient(150deg, #0c1c10 0%, #0a0a0a 100%)',
-              border: '1px solid rgba(0,255,136,0.25)',
-              boxShadow: '0 0 60px rgba(0,255,136,0.05)',
-            }}>
-            <div>
-              <div className="flex items-center gap-3 mb-5">
-                <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
-                  style={{ backgroundColor: 'var(--accent)' }}>
-                  <FiGlobe className="text-[#0a0a0a]" size={16} />
-                </div>
-                <p className="text-xs font-mono uppercase tracking-widest text-gray-500">
-                  <StreamText speed={40} startDelay={CASE_CARD + 100}>Case Study</StreamText>
-                </p>
-              </div>
-              <h2 className="text-2xl sm:text-3xl font-bold text-white mb-5">
-                <StreamText speed={45} startDelay={CASE_CARD + 350}>Malone Septic &amp; Excavation</StreamText>
-              </h2>
-              <p className="text-gray-400 leading-relaxed">
-                <StreamText speed={20} startDelay={CASE_CARD + 700}>
-                  A local excavation company had no web presence at all. We built and launched a full site — branding, copy, contact forms, SEO — in one week. Now they show up when customers search, and leads come in while the owner is on the job.
-                </StreamText>
-              </p>
-            </div>
-            <div className="grid grid-cols-3 gap-6 mt-8">
-              {[
-                { stat: '0 → Live', label: 'Web Presence',      delay: CASE_CARD + 2600 },
-                { stat: '1 Week',   label: 'Start to Launch',   delay: CASE_CARD + 2900 },
-                { stat: 'Organic',  label: 'Leads from Search', delay: CASE_CARD + 3200 },
-              ].map(({ stat, label, delay }) => (
-                <motion.div key={label} {...appear(delay)}>
-                  <div className="text-2xl font-bold font-mono" style={{ color: 'var(--accent)' }}>
-                    <StreamText speed={55} startDelay={delay + 80}>{stat}</StreamText>
-                  </div>
-                  <div className="text-xs text-gray-600 mt-1">
-                    <StreamText speed={40} startDelay={delay + 280}>{label}</StreamText>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-
-          {/* Your business here */}
-          <motion.div
-            {...appear(YOUR_CARD)}
-            className="p-8 sm:p-10 rounded-2xl border border-dashed border-white/10 flex flex-col items-start justify-between gap-8"
-            style={{ background: '#0d0d0d' }}>
-            <div>
-              <h2 className="text-xl font-bold text-gray-300 mb-3">
-                <StreamText speed={50} startDelay={YOUR_CARD + 80}>Your Business Here</StreamText>
-              </h2>
-              <p className="text-gray-500 leading-relaxed text-sm">
-                <StreamText speed={22} startDelay={YOUR_CARD + 380}>
-                  Working with small businesses in Arkansas and Colorado right now. If you&apos;re curious what AI could actually do for your operation — let&apos;s have a straight conversation.
-                </StreamText>
-              </p>
-            </div>
-            <Link href="/contact"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm transition-all hover:scale-105"
-              style={{ backgroundColor: 'var(--accent)', color: '#0a0a0a' }}>
-              Get in Touch <FiArrowRight size={14} />
-            </Link>
-          </motion.div>
-
-        </div>
-      </div>
-    </main>
-  );
+  return <WorkClient />;
 }


### PR DESCRIPTION
## Summary

- Split all `'use client'` pages into a server wrapper + client component so Next.js can export `metadata` per route
- Per-page `title`, `description`, Open Graph, and Twitter card tags on all 5 routes
- `LocalBusiness` JSON-LD schema injected in layout (helps local search)
- `/sitemap.xml` and `/robots.txt` via Next.js file-based routes
- `metadataBase` + title template set on layout so relative OG image URLs resolve correctly

## Note
You'll want to add an actual OG image at `public/og-image.jpg` (1200×630) — referenced in all the metadata but not yet in the repo. The logo in `/public/contraptionsoft_logo.jpg` could be cropped/padded to fit, or a proper social card image designed.

## Test plan
- [ ] `curl https://contraptionsoft.com/sitemap.xml` returns all 5 routes
- [ ] `curl https://contraptionsoft.com/robots.txt` returns correct allow/sitemap rules
- [ ] View source on each page — confirm unique `<title>` and `<meta>` tags per route
- [ ] Paste any page URL into [opengraph.xyz](https://www.opengraph.xyz) to verify OG preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)