### PR TITLE
Redesign products page: sell roles, not software

### DIFF
--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -30,10 +30,6 @@ const EXAMPLES = [
     agent: "On it. First messages going out now. I'll flag you if anyone pushes back or goes quiet.",
   },
   {
-    user: "Every Friday at 4pm, check in with the crew and ask where everything stands.",
-    agent: "Scheduled. First check-in this Friday at 4pm. I'll roll up the responses and send them to you.",
-  },
-  {
     user: "When a Google review comes in, draft me a response to approve before it goes out.",
     agent: "Watching for new reviews. I'll have a draft in your inbox before you even see the notification.",
   },
@@ -57,9 +53,6 @@ export default function Products() {
 
         {/* Header */}
         <div className="mb-16">
-          <motion.p {...appear(0)} className="text-xs font-mono tracking-[0.2em] uppercase mb-4" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={45}>What we build</StreamText>
-          </motion.p>
           <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-[52px] font-bold text-white leading-[1.1] tracking-tight mb-6">
             <StreamText speed={52} startDelay={HEADER_H1}>
               Your business is leaking.
@@ -98,7 +91,7 @@ export default function Products() {
             An AI employee handles this.
           </p>
           <p className="text-gray-500 text-sm leading-relaxed max-w-xl">
-            On standby around the clock. Reachable through your messaging app. You tell it what to do — once, on a schedule, or when something happens — and it handles it. You don&apos;t manage software. You just talk to it.
+            You message it. It handles it. On standby 24/7, reachable through whatever app you already use. You&apos;re not managing software — you&apos;re talking to someone who works for you.
           </p>
         </motion.div>
 
@@ -128,14 +121,6 @@ export default function Products() {
           ))}
         </div>
 
-        {/* Flexibility note */}
-        <motion.p
-          {...appear(EXAMPLES_START + EXAMPLES.length * EXAMPLE_GAP + 100)}
-          className="text-gray-600 text-sm leading-relaxed mb-12 max-w-lg"
-        >
-          These are examples. Your agent does what your business actually needs — one thing or ten, on demand or on a schedule. Start small. Add more when it makes sense.
-        </motion.p>
-
         {/* CTA */}
         <motion.div
           {...appear(EXAMPLES_START + EXAMPLES.length * EXAMPLE_GAP + 300)}
@@ -144,7 +129,8 @@ export default function Products() {
         >
           <div>
             <p className="text-white font-bold text-xl mb-1">Tell us what&apos;s slipping.</p>
-            <p className="text-gray-500 text-sm">We&apos;ll figure out whether an agent makes sense and what it would actually do for you.</p>
+            <p className="text-gray-500 text-sm mb-3">We&apos;ll figure out whether an agent makes sense and what it would actually do for you.</p>
+            <p className="text-gray-700 text-xs font-mono">Veteran-owned. Fort Collins, CO. Real people, not a platform.</p>
           </div>
           <Link
             href="/contact"

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { FiArrowRight, FiZap, FiClock, FiEye } from 'react-icons/fi';
+import { FiArrowRight } from 'react-icons/fi';
 import StreamText from '../components/StreamText';
 
 function appear(delayMs: number) {
@@ -13,136 +13,138 @@ function appear(delayMs: number) {
   };
 }
 
-// Example prompts grouped by flavor
+const PAIN_POINTS = [
+  "The call that came in at 5:45pm. Nobody answered. They went with somebody else.",
+  "The invoice you sent three weeks ago. Still unpaid. You keep meaning to follow up.",
+  "The quote you put together, sent it off, and never heard back. You never followed up either.",
+  "Monday morning. You spend two hours on things that aren't the job.",
+];
+
 const EXAMPLES = [
   {
-    icon: FiZap,
-    label: 'On demand',
-    desc: 'Just ask and it does it.',
-    prompts: [
-      { user: 'Hey, update the products page to include the new HVAC package we added last week.', agent: 'Done — product page updated and deployed.' },
-      { user: "Pull all the invoices from March and tell me who's overdue.", agent: 'Found 4 overdue invoices totaling $3,840. Want me to send follow-ups?' },
-      { user: 'Summarize the last 30 emails from clients.', agent: "Here's a rundown — 3 need a response today, 1 looks like a new lead." },
-    ],
+    user: "Hey, if someone calls after hours and asks about pricing, handle it and take down their info.",
+    agent: "Got it. I'll pick up after-hours calls, walk them through pricing, and send you a summary with their contact info.",
   },
   {
-    icon: FiClock,
-    label: 'Scheduled',
-    desc: 'Set it once and it runs on its own.',
-    prompts: [
-      { user: 'At 5pm every Friday, message the crew and ask where things stand for the week.', agent: "Got it — I'll check in with everyone at 5pm Fridays." },
-      { user: 'Every morning, check my inbox and flag anything urgent.', agent: "Running daily at 8am. You'll hear from me if something needs attention." },
-      { user: 'On the 1st of each month, pull a revenue summary from Stripe and drop it in Slack.', agent: 'Scheduled. First report goes out May 1st.' },
-    ],
+    user: "Chase the three unpaid invoices from March. Give them a week, then follow up again.",
+    agent: "On it. First messages going out now. I'll flag you if anyone pushes back or goes quiet.",
   },
   {
-    icon: FiEye,
-    label: 'Always watching',
-    desc: "Monitors things so you don't have to.",
-    prompts: [
-      { user: 'If the site goes down, text me immediately.', agent: "Watching it. You'll get a text within a minute of any downtime." },
-      { user: 'When a new Google Review comes in, draft a response for me to approve.', agent: "On it — I'll have a draft ready before you even see the notification." },
-      { user: 'Keep an eye on the competitor pricing page and let me know if anything changes.', agent: "I'll check weekly and flag any updates." },
-    ],
+    user: "Every Friday at 4pm, check in with the crew and ask where everything stands.",
+    agent: "Scheduled. First check-in this Friday at 4pm. I'll roll up the responses and send them to you.",
+  },
+  {
+    user: "When a Google review comes in, draft me a response to approve before it goes out.",
+    agent: "Watching for new reviews. I'll have a draft in your inbox before you even see the notification.",
+  },
+  {
+    user: "Go through last month's emails and pull out anything that looks like a lead we dropped.",
+    agent: "Found 6 conversations that went cold. Drafting follow-ups — want to review before I send?",
   },
 ];
 
-const HEADER_H1  = 300;
-const HEADER_SUB = 650;
-const HEADER_DONE = HEADER_SUB + 22 * 22;
-
-const SECTION_GAP = 280;
+const HEADER_H1   = 300;
+const HEADER_DONE = 900;
+const PAIN_BASE   = HEADER_DONE + 200;
+const PAIN_GAP    = 180;
+const EXAMPLES_START = PAIN_BASE + PAIN_POINTS.length * PAIN_GAP + 500;
+const EXAMPLE_GAP = 200;
 
 export default function Products() {
   return (
     <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-3xl mx-auto">
 
         {/* Header */}
-        <div className="mb-16 max-w-2xl">
-          <motion.p {...appear(0)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
+        <div className="mb-16">
+          <motion.p {...appear(0)} className="text-xs font-mono tracking-[0.2em] uppercase mb-4" style={{ color: 'var(--accent)' }}>
             <StreamText speed={45}>What we build</StreamText>
           </motion.p>
-          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight mb-4">
-            <StreamText speed={48} startDelay={HEADER_H1}>An AI you just talk to.</StreamText>
+          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-[52px] font-bold text-white leading-[1.1] tracking-tight mb-6">
+            <StreamText speed={52} startDelay={HEADER_H1}>
+              Your business is leaking.
+            </StreamText>
           </motion.h1>
-          <motion.p {...appear(HEADER_SUB)} className="text-gray-500 leading-relaxed">
-            <StreamText speed={22} startDelay={HEADER_SUB}>
-              On standby around the clock. Reachable through your messaging app. You tell it what to do — once, or on a schedule — and it handles it. One agent or several, it&apos;s up to you.
+          <motion.p {...appear(600)} className="text-gray-500 leading-relaxed max-w-xl">
+            <StreamText speed={22} startDelay={600}>
+              Missed calls. Unpaid invoices. Follow-ups that never happened. Not because you don&apos;t care — because there aren&apos;t enough hours. We build AI that plugs the gaps.
             </StreamText>
           </motion.p>
         </div>
 
-        {/* Example sections */}
-        {EXAMPLES.map(({ icon: Icon, label, desc, prompts }, sIdx) => {
-          const sectionAt = HEADER_DONE + 300 + sIdx * SECTION_GAP;
-          return (
-            <motion.div
-              key={label}
-              {...appear(sectionAt)}
-              className="mb-12"
-            >
-              {/* Section label */}
-              <div className="flex items-center gap-2.5 mb-5">
-                <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
-                  style={{ backgroundColor: 'rgba(0,255,136,0.12)' }}>
-                  <Icon size={14} style={{ color: 'var(--accent)' }} />
-                </div>
-                <div>
-                  <span className="text-sm font-semibold text-white">{label}</span>
-                  <span className="text-gray-600 text-sm"> — {desc}</span>
-                </div>
-              </div>
+        {/* Pain points */}
+        <div className="mb-16">
+          <motion.p {...appear(PAIN_BASE - 200)} className="text-xs font-mono text-gray-600 uppercase tracking-widest mb-5">
+            Sound familiar?
+          </motion.p>
+          <ul className="space-y-3">
+            {PAIN_POINTS.map((point, i) => (
+              <motion.li
+                key={i}
+                {...appear(PAIN_BASE + i * PAIN_GAP)}
+                className="flex items-start gap-4 py-4 px-5 rounded-xl border border-white/6"
+                style={{ background: '#0d0d0d' }}
+              >
+                <span className="text-gray-700 font-mono text-sm flex-shrink-0 mt-0.5">{String(i + 1).padStart(2, '0')}</span>
+                <p className="text-gray-400 text-sm leading-relaxed">{point}</p>
+              </motion.li>
+            ))}
+          </ul>
+        </div>
 
-              {/* Prompt cards */}
-              <div className="space-y-3 pl-0">
-                {prompts.map(({ user, agent }, pIdx) => (
-                  <motion.div
-                    key={pIdx}
-                    initial={{ opacity: 0, y: 6 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: (sectionAt + 100 + pIdx * 180) / 1000, duration: 0.35, ease: 'easeOut' }}
-                    className="rounded-xl border border-white/8 overflow-hidden"
-                    style={{ background: '#0f0f0f' }}
-                  >
-                    {/* User message */}
-                    <div className="px-5 py-4 flex items-start gap-3 border-b border-white/6">
-                      <div className="w-6 h-6 rounded-full bg-white/10 flex-shrink-0 flex items-center justify-center mt-0.5">
-                        <span className="text-[10px] text-gray-400 font-mono">You</span>
-                      </div>
-                      <p className="text-sm text-gray-300 leading-relaxed">&ldquo;{user}&rdquo;</p>
-                    </div>
-                    {/* Agent reply */}
-                    <div className="px-5 py-4 flex items-start gap-3" style={{ background: 'rgba(0,255,136,0.03)' }}>
-                      <div className="w-6 h-6 rounded-full flex-shrink-0 flex items-center justify-center mt-0.5"
-                        style={{ backgroundColor: 'rgba(0,255,136,0.15)' }}>
-                        <span className="text-[10px] font-mono" style={{ color: 'var(--accent)' }}>AI</span>
-                      </div>
-                      <p className="text-sm text-gray-400 leading-relaxed">{agent}</p>
-                    </div>
-                  </motion.div>
-                ))}
-              </div>
-            </motion.div>
-          );
-        })}
-
-        {/* Bottom context */}
-        <motion.div {...appear(HEADER_DONE + 300 + EXAMPLES.length * SECTION_GAP + 200)} className="mb-10">
-          <p className="text-gray-600 text-sm leading-relaxed max-w-xl">
-            These are examples — not a fixed menu. Your agent does what you tell it, in the order you tell it, on whatever schedule makes sense for your business. Start with one thing. Add more as you need it.
+        {/* Bridge */}
+        <motion.div {...appear(EXAMPLES_START - 300)} className="mb-12">
+          <p className="text-white text-xl font-semibold leading-snug mb-3">
+            An AI employee handles this.
+          </p>
+          <p className="text-gray-500 text-sm leading-relaxed max-w-xl">
+            On standby around the clock. Reachable through your messaging app. You tell it what to do — once, on a schedule, or when something happens — and it handles it. You don&apos;t manage software. You just talk to it.
           </p>
         </motion.div>
 
+        {/* Example conversations */}
+        <div className="mb-12 space-y-3">
+          {EXAMPLES.map(({ user, agent }, i) => (
+            <motion.div
+              key={i}
+              {...appear(EXAMPLES_START + i * EXAMPLE_GAP)}
+              className="rounded-xl border border-white/8 overflow-hidden"
+              style={{ background: '#0f0f0f' }}
+            >
+              <div className="px-5 py-4 flex items-start gap-3 border-b border-white/6">
+                <div className="w-6 h-6 rounded-full bg-white/8 flex-shrink-0 flex items-center justify-center mt-0.5">
+                  <span className="text-[9px] text-gray-500 font-mono">You</span>
+                </div>
+                <p className="text-sm text-gray-300 leading-relaxed">&ldquo;{user}&rdquo;</p>
+              </div>
+              <div className="px-5 py-4 flex items-start gap-3" style={{ background: 'rgba(0,255,136,0.03)' }}>
+                <div className="w-6 h-6 rounded-full flex-shrink-0 flex items-center justify-center mt-0.5"
+                  style={{ backgroundColor: 'rgba(0,255,136,0.12)' }}>
+                  <span className="text-[9px] font-mono" style={{ color: 'var(--accent)' }}>AI</span>
+                </div>
+                <p className="text-sm text-gray-400 leading-relaxed">{agent}</p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Flexibility note */}
+        <motion.p
+          {...appear(EXAMPLES_START + EXAMPLES.length * EXAMPLE_GAP + 100)}
+          className="text-gray-600 text-sm leading-relaxed mb-12 max-w-lg"
+        >
+          These are examples. Your agent does what your business actually needs — one thing or ten, on demand or on a schedule. Start small. Add more when it makes sense.
+        </motion.p>
+
         {/* CTA */}
         <motion.div
-          {...appear(HEADER_DONE + 300 + EXAMPLES.length * SECTION_GAP + 400)}
-          className="rounded-2xl border border-white/8 p-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6"
+          {...appear(EXAMPLES_START + EXAMPLES.length * EXAMPLE_GAP + 300)}
+          className="rounded-2xl border border-white/8 p-8 sm:p-10 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6"
           style={{ background: '#0d0d0d' }}
         >
           <div>
-            <p className="text-white font-bold text-xl mb-1">Want to see what it could do for you?</p>
-            <p className="text-gray-500 text-sm">Tell us what you're dealing with. We'll figure out whether an agent makes sense.</p>
+            <p className="text-white font-bold text-xl mb-1">Tell us what&apos;s slipping.</p>
+            <p className="text-gray-500 text-sm">We&apos;ll figure out whether an agent makes sense and what it would actually do for you.</p>
           </div>
           <Link
             href="/contact"

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -21,8 +21,8 @@ const EXAMPLES = [
     desc: 'Just ask and it does it.',
     prompts: [
       { user: 'Hey, update the products page to include the new HVAC package we added last week.', agent: 'Done — product page updated and deployed.' },
-      { user: 'Pull all the invoices from March and tell me who's overdue.', agent: 'Found 4 overdue invoices totaling $3,840. Want me to send follow-ups?' },
-      { user: 'Summarize the last 30 emails from clients.', agent: 'Here's a rundown — 3 need a response today, 1 looks like a new lead.' },
+      { user: "Pull all the invoices from March and tell me who's overdue.", agent: 'Found 4 overdue invoices totaling $3,840. Want me to send follow-ups?' },
+      { user: 'Summarize the last 30 emails from clients.', agent: "Here's a rundown — 3 need a response today, 1 looks like a new lead." },
     ],
   },
   {
@@ -30,19 +30,19 @@ const EXAMPLES = [
     label: 'Scheduled',
     desc: 'Set it once and it runs on its own.',
     prompts: [
-      { user: 'At 5pm every Friday, message the crew and ask where things stand for the week.', agent: 'Got it — I'll check in with everyone at 5pm Fridays.' },
-      { user: 'Every morning, check my inbox and flag anything urgent.', agent: 'Running daily at 8am. You'll hear from me if something needs attention.' },
+      { user: 'At 5pm every Friday, message the crew and ask where things stand for the week.', agent: "Got it — I'll check in with everyone at 5pm Fridays." },
+      { user: 'Every morning, check my inbox and flag anything urgent.', agent: "Running daily at 8am. You'll hear from me if something needs attention." },
       { user: 'On the 1st of each month, pull a revenue summary from Stripe and drop it in Slack.', agent: 'Scheduled. First report goes out May 1st.' },
     ],
   },
   {
     icon: FiEye,
     label: 'Always watching',
-    desc: 'Monitors things so you don't have to.',
+    desc: "Monitors things so you don't have to.",
     prompts: [
-      { user: 'If the site goes down, text me immediately.', agent: 'Watching it. You'll get a text within a minute of any downtime.' },
-      { user: 'When a new Google Review comes in, draft a response for me to approve.', agent: 'On it — I'll have a draft ready before you even see the notification.' },
-      { user: 'Keep an eye on the competitor pricing page and let me know if anything changes.', agent: 'I'll check weekly and flag any updates.' },
+      { user: 'If the site goes down, text me immediately.', agent: "Watching it. You'll get a text within a minute of any downtime." },
+      { user: 'When a new Google Review comes in, draft a response for me to approve.', agent: "On it — I'll have a draft ready before you even see the notification." },
+      { user: 'Keep an eye on the competitor pricing page and let me know if anything changes.', agent: "I'll check weekly and flag any updates." },
     ],
   },
 ];

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -1,109 +1,151 @@
 'use client';
 
+import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { FiMic, FiTerminal, FiDatabase, FiZap, FiGlobe, FiCheck, FiArrowRight } from 'react-icons/fi';
+import {
+  FiPhone, FiFileText, FiTrendingUp, FiEye, FiBook, FiCalendar,
+  FiCheck, FiArrowRight,
+} from 'react-icons/fi';
 import StreamText from '../components/StreamText';
 
-// ms to stream N words at a given speed
 const t = (words: number, speed = 28) => words * speed;
 
-// Timings — each element appears, then its text immediately starts streaming
-const HEADER_LABEL   = 0;
-const HEADER_H1      = 400;
-const HEADER_SUB     = 900;
-const HEADER_DONE    = HEADER_SUB + t(18, 22); // ~1300ms
-
-const CARD_1         = HEADER_DONE + 200;       // ~1500ms
-const CARD_2         = CARD_1 + 900;            // ~2400ms
-const CARD_3         = CARD_2 + 900;            // ~3300ms
-
-const COMP_1         = CARD_3 + 1100;           // ~4400ms
-const COMP_2         = COMP_1 + 1400;           // ~5800ms
-
-// Per-card list item delays relative to card appearance
-const ITEM_OFFSET = (descWords: number, descSpeed = 22) =>
-  t(2, 50) + 100 + t(descWords, descSpeed);
+const HEADER_LABEL = 0;
+const HEADER_H1    = 350;
+const HEADER_SUB   = 750;
+const HEADER_DONE  = HEADER_SUB + t(22, 22);
 
 function appear(delayMs: number) {
   return {
-    initial: { opacity: 0, y: 6 },
+    initial: { opacity: 0, y: 8 },
     animate: { opacity: 1, y: 0 },
-    transition: { delay: delayMs / 1000, duration: 0.35, ease: 'easeOut' as const },
+    transition: { delay: delayMs / 1000, duration: 0.4, ease: 'easeOut' as const },
   };
 }
+
+const ROLES = [
+  {
+    icon: FiPhone,
+    title: 'Front Desk Agent',
+    tagline: 'Handles your phones and inbound messages so nothing slips.',
+    items: [
+      'Answers after-hours calls and captures leads',
+      'Responds to contact form submissions with a personalized follow-up',
+      'Handles common FAQ-style questions without human involvement',
+      'Sends appointment reminders and follow-ups via SMS or email',
+    ],
+  },
+  {
+    icon: FiFileText,
+    title: 'Office Manager',
+    tagline: 'Keeps the back office moving without you chasing it.',
+    items: [
+      'Drafts and sends invoices, then follows up on unpaid ones',
+      'Pulls reports from QuickBooks, Stripe, or Square and summarizes them in plain English',
+      'Monitors your Gmail inbox, triages by urgency, and drafts replies for review',
+      'Fills out repetitive forms — permits, vendor onboarding, and similar',
+    ],
+  },
+  {
+    icon: FiTrendingUp,
+    title: 'Sales Rep',
+    tagline: 'Works your pipeline without you managing it.',
+    items: [
+      'Enriches inbound leads — looks up the business, pulls contact info, scores them',
+      'Moves deals through pipeline stages based on email activity',
+      'Sends drip follow-up sequences after a quote goes out',
+      'Alerts you when a high-value lead goes cold',
+    ],
+  },
+  {
+    icon: FiEye,
+    title: 'On-Call Monitor',
+    tagline: 'Watches what matters and flags anything that needs attention.',
+    items: [
+      'Monitors your website uptime and pings you if it goes down',
+      'Scrapes competitor pricing or job postings on a schedule',
+      'Watches Google Reviews and drafts a response when a new one drops',
+      'Tracks mentions of your business name across the web',
+    ],
+  },
+  {
+    icon: FiBook,
+    title: 'Research Assistant',
+    tagline: 'Answers questions and drafts documents from your own material.',
+    items: [
+      'Answers employee questions against your document library',
+      'Summarizes a week of emails or Slack messages every Monday morning',
+      'Generates a first draft of a proposal or SOW from a few bullet points',
+      'Transcribes voicemails and routes them to the right person',
+    ],
+  },
+  {
+    icon: FiCalendar,
+    title: 'Executive Assistant',
+    tagline: 'Handles the scheduling and coordination you keep putting off.',
+    items: [
+      'Finds a meeting time across multiple calendars and sends the invite',
+      'Reminds you about recurring tasks before you forget them',
+      'Auto-schedules social posts from a content queue',
+      'Tracks recurring deadlines so they don\'t sneak up on you',
+    ],
+  },
+];
+
+// Stagger card appearance after header
+const CARD_BASE = HEADER_DONE + 200;
+const CARD_GAP  = 120;
 
 export default function Products() {
   return (
     <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
       <div className="max-w-6xl mx-auto">
 
-        {/* Section header — streams first */}
-        <div className="mb-14">
+        {/* Header */}
+        <div className="mb-14 max-w-2xl">
           <motion.p {...appear(HEADER_LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={45} startDelay={HEADER_LABEL}>01 — What We Build</StreamText>
+            <StreamText speed={45} startDelay={HEADER_LABEL}>01 — Your AI Team</StreamText>
           </motion.p>
-          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight max-w-xl">
-            <StreamText speed={50} startDelay={HEADER_H1}>AI Tools Built for the Real World</StreamText>
+          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight">
+            <StreamText speed={50} startDelay={HEADER_H1}>Hire by role, not by software.</StreamText>
           </motion.h1>
-          <motion.p {...appear(HEADER_SUB)} className="mt-4 text-gray-500 max-w-xl">
+          <motion.p {...appear(HEADER_SUB)} className="mt-4 text-gray-500 leading-relaxed">
             <StreamText speed={22} startDelay={HEADER_SUB}>
-              Not vaporware. Not demos. Deployed tools that run your business while you&apos;re busy running your business.
+              Each agent handles a specific business function — customer calls, invoicing, lead follow-up, whatever you&apos;re falling behind on. You pick the role. We build and run the agent.
             </StreamText>
           </motion.p>
         </div>
 
-        {/* Product cards — appear one at a time */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-
-          {[
-            {
-              icon: <FiMic className="text-[#0a0a0a]" size={18} />,
-              title: 'Voice Agent',
-              desc: 'An AI that answers your phone after hours, books appointments, handles FAQs, and routes urgent calls. No lead goes cold.',
-              items: ['Answers calls 24/7', 'Books appointments automatically', 'Handles common questions', 'Escalates urgent issues to you'],
-              appear: CARD_1,
-            },
-            {
-              icon: <FiTerminal className="text-[#0a0a0a]" size={18} />,
-              title: 'AI Agents',
-              desc: 'Always-on AI you reach through your messaging app. Morning briefing, web deploy, research — just ask.',
-              items: ['Discord, Slack, or SMS', 'Builds and deploys web projects', 'Runs 24/7'],
-              appear: CARD_2,
-            },
-            {
-              icon: <FiDatabase className="text-[#0a0a0a]" size={18} />,
-              title: 'Local File Search',
-              desc: 'Ask a question, get an answer from your own documents. No cloud upload. Your data stays put.',
-              items: ['PDFs, Word, spreadsheets', 'No cloud required', 'Private by design'],
-              appear: CARD_3,
-            },
-          ].map(({ icon, title, desc, items, appear: cardAt }) => {
-            const textAt   = cardAt + 80;
-            const descAt   = textAt + t(title.split(' ').length, 50) + 100;
-            const itemBase = descAt + t(desc.split(' ').length, 22) + 150;
+        {/* Role cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {ROLES.map(({ icon: Icon, title, tagline, items }, idx) => {
+            const cardAt = CARD_BASE + idx * CARD_GAP;
+            const itemBase = cardAt + 300;
             return (
               <motion.div
                 key={title}
-                initial={{ opacity: 0, y: 8 }}
+                initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: cardAt / 1000, duration: 0.4, ease: 'easeOut' }}
-                className="p-6 sm:p-7 rounded-2xl border border-white/8 bg-[#111] hover:border-white/15 hover:scale-[1.02] transition-colors group cursor-default"
+                className="p-6 sm:p-7 rounded-2xl border border-white/8 bg-[#111] hover:border-white/15 transition-colors group cursor-default flex flex-col"
               >
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform"
+                <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-5 group-hover:scale-110 transition-transform flex-shrink-0"
                   style={{ backgroundColor: 'var(--accent)' }}>
-                  {icon}
+                  <Icon className="text-[#0a0a0a]" size={18} />
                 </div>
-                <h2 className="text-xl font-bold text-white mb-2 font-mono">
-                  <StreamText speed={50} startDelay={textAt}>{title}</StreamText>
+
+                <h2 className="text-lg font-bold text-white mb-1 font-mono">
+                  <StreamText speed={50} startDelay={cardAt + 60}>{title}</StreamText>
                 </h2>
                 <p className="text-sm text-gray-500 leading-relaxed mb-5">
-                  <StreamText speed={22} startDelay={descAt}>{desc}</StreamText>
+                  <StreamText speed={24} startDelay={cardAt + 180}>{tagline}</StreamText>
                 </p>
-                <ul className="space-y-2">
+
+                <ul className="space-y-2.5 mt-auto">
                   {items.map((item, i) => (
-                    <li key={item} className="flex items-center gap-2 text-xs text-gray-400">
-                      <FiCheck size={11} style={{ color: 'var(--accent)', flexShrink: 0 }} />
-                      <StreamText speed={32} startDelay={itemBase + i * 260}>{item}</StreamText>
+                    <li key={item} className="flex items-start gap-2 text-xs text-gray-400 leading-snug">
+                      <FiCheck size={11} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 2 }} />
+                      <StreamText speed={30} startDelay={itemBase + i * 220}>{item}</StreamText>
                     </li>
                   ))}
                 </ul>
@@ -112,75 +154,26 @@ export default function Products() {
           })}
         </div>
 
-        {/* Comparison blocks — appear after cards */}
-        <div className="mt-4 space-y-3">
-          {[
-            {
-              icon: <FiZap size={14} />,
-              topic: 'Workflow Automation',
-              before: ['Pick a tool (Zapier, Make, n8n…)', 'Configure triggers and steps', 'Debug it when something breaks', 'Start over for every new workflow'],
-              after: ['"Send me a summary every Monday"', '"Flag any invoice over $500"', '"Follow up if no reply in 2 days"', 'Just say it. Agent handles the rest.'],
-              appear: COMP_1,
-            },
-            {
-              icon: <FiGlobe size={14} />,
-              topic: 'Web Presence',
-              before: ['Find and vet a web developer', 'Wait days for a response', 'Pay for every small change', 'Hope they understood what you wanted'],
-              after: ["Chat with it anytime — it doesn't sleep", 'It codes, ships, and handles SEO', 'Changes happen in minutes', 'No queue. No invoice. No delay.'],
-              appear: COMP_2,
-            },
-          ].map(({ icon, topic, before, after, appear: blockAt }) => (
-            <motion.div
-              key={topic}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: blockAt / 1000, duration: 0.4, ease: 'easeOut' }}
-              className="rounded-2xl border border-white/8 overflow-hidden"
-              style={{ background: '#0d0d0d' }}
-            >
-              <div className="px-6 py-3 border-b border-white/8 flex items-center gap-2">
-                <span className="text-gray-500">{icon}</span>
-                <span className="text-xs font-mono text-gray-400 uppercase tracking-widest">
-                  <StreamText speed={40} startDelay={blockAt + 80}>{topic}</StreamText>
-                </span>
-              </div>
-              <div className="flex flex-col sm:flex-row">
-                <div className="flex-1 p-6 sm:p-7">
-                  <p className="text-xs font-mono text-gray-600 uppercase tracking-widest mb-4">Without an agent</p>
-                  <ul className="space-y-3">
-                    {before.map((item, i) => (
-                      <li key={item} className="flex items-start gap-3 text-sm text-gray-600">
-                        <span className="mt-1 text-gray-700 flex-shrink-0 font-mono">—</span>
-                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="hidden sm:flex items-center justify-center px-2">
-                  <div className="flex flex-col items-center gap-1">
-                    <div className="w-px h-8 bg-white/10" />
-                    <FiArrowRight size={16} style={{ color: 'var(--accent)' }} />
-                    <div className="w-px h-8 bg-white/10" />
-                  </div>
-                </div>
-                <div className="sm:hidden flex items-center justify-center py-2 border-t border-white/8">
-                  <FiArrowRight size={16} className="rotate-90" style={{ color: 'var(--accent)' }} />
-                </div>
-                <div className="flex-1 p-6 sm:p-7 border-t sm:border-t-0 sm:border-l border-white/8" style={{ background: 'rgba(0,255,136,0.03)' }}>
-                  <p className="text-xs font-mono uppercase tracking-widest mb-4" style={{ color: 'var(--accent)' }}>With an agent</p>
-                  <ul className="space-y-3">
-                    {after.map((item, i) => (
-                      <li key={item} className="flex items-start gap-3 text-sm text-gray-200">
-                        <FiCheck size={13} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 3 }} />
-                        <StreamText speed={26} startDelay={blockAt + 300 + i * 380}>{item}</StreamText>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </motion.div>
-          ))}
-        </div>
+        {/* CTA */}
+        <motion.div
+          {...appear(CARD_BASE + ROLES.length * CARD_GAP + 400)}
+          className="mt-12 rounded-2xl border border-white/8 p-8 sm:p-10 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6"
+          style={{ background: '#0d0d0d' }}
+        >
+          <div>
+            <p className="text-white font-bold text-xl mb-1">Ready to staff up?</p>
+            <p className="text-gray-500 text-sm max-w-md">
+              Tell us which role would make the biggest difference. We&apos;ll scope it, build it, and keep it running.
+            </p>
+          </div>
+          <Link
+            href="/contact"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-semibold text-[#0a0a0a] whitespace-nowrap transition-all hover:scale-105 active:scale-95 flex-shrink-0"
+            style={{ backgroundColor: 'var(--accent)', boxShadow: '0 0 24px rgba(0,255,136,0.2)' }}
+          >
+            Build your team <FiArrowRight />
+          </Link>
+        </motion.div>
 
       </div>
     </main>

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -2,18 +2,8 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import {
-  FiPhone, FiFileText, FiTrendingUp, FiEye, FiBook, FiCalendar,
-  FiCheck, FiArrowRight,
-} from 'react-icons/fi';
+import { FiArrowRight, FiZap, FiClock, FiEye } from 'react-icons/fi';
 import StreamText from '../components/StreamText';
-
-const t = (words: number, speed = 28) => words * speed;
-
-const HEADER_LABEL = 0;
-const HEADER_H1    = 350;
-const HEADER_SUB   = 750;
-const HEADER_DONE  = HEADER_SUB + t(22, 22);
 
 function appear(delayMs: number) {
   return {
@@ -23,155 +13,143 @@ function appear(delayMs: number) {
   };
 }
 
-const ROLES = [
+// Example prompts grouped by flavor
+const EXAMPLES = [
   {
-    icon: FiPhone,
-    title: 'Front Desk Agent',
-    tagline: 'Handles your phones and inbound messages so nothing slips.',
-    items: [
-      'Answers after-hours calls and captures leads',
-      'Responds to contact form submissions with a personalized follow-up',
-      'Handles common FAQ-style questions without human involvement',
-      'Sends appointment reminders and follow-ups via SMS or email',
+    icon: FiZap,
+    label: 'On demand',
+    desc: 'Just ask and it does it.',
+    prompts: [
+      { user: 'Hey, update the products page to include the new HVAC package we added last week.', agent: 'Done — product page updated and deployed.' },
+      { user: 'Pull all the invoices from March and tell me who's overdue.', agent: 'Found 4 overdue invoices totaling $3,840. Want me to send follow-ups?' },
+      { user: 'Summarize the last 30 emails from clients.', agent: 'Here's a rundown — 3 need a response today, 1 looks like a new lead.' },
     ],
   },
   {
-    icon: FiFileText,
-    title: 'Office Manager',
-    tagline: 'Keeps the back office moving without you chasing it.',
-    items: [
-      'Drafts and sends invoices, then follows up on unpaid ones',
-      'Pulls reports from QuickBooks, Stripe, or Square and summarizes them in plain English',
-      'Monitors your Gmail inbox, triages by urgency, and drafts replies for review',
-      'Fills out repetitive forms — permits, vendor onboarding, and similar',
-    ],
-  },
-  {
-    icon: FiTrendingUp,
-    title: 'Sales Rep',
-    tagline: 'Works your pipeline without you managing it.',
-    items: [
-      'Enriches inbound leads — looks up the business, pulls contact info, scores them',
-      'Moves deals through pipeline stages based on email activity',
-      'Sends drip follow-up sequences after a quote goes out',
-      'Alerts you when a high-value lead goes cold',
+    icon: FiClock,
+    label: 'Scheduled',
+    desc: 'Set it once and it runs on its own.',
+    prompts: [
+      { user: 'At 5pm every Friday, message the crew and ask where things stand for the week.', agent: 'Got it — I'll check in with everyone at 5pm Fridays.' },
+      { user: 'Every morning, check my inbox and flag anything urgent.', agent: 'Running daily at 8am. You'll hear from me if something needs attention.' },
+      { user: 'On the 1st of each month, pull a revenue summary from Stripe and drop it in Slack.', agent: 'Scheduled. First report goes out May 1st.' },
     ],
   },
   {
     icon: FiEye,
-    title: 'On-Call Monitor',
-    tagline: 'Watches what matters and flags anything that needs attention.',
-    items: [
-      'Monitors your website uptime and pings you if it goes down',
-      'Scrapes competitor pricing or job postings on a schedule',
-      'Watches Google Reviews and drafts a response when a new one drops',
-      'Tracks mentions of your business name across the web',
-    ],
-  },
-  {
-    icon: FiBook,
-    title: 'Research Assistant',
-    tagline: 'Answers questions and drafts documents from your own material.',
-    items: [
-      'Answers employee questions against your document library',
-      'Summarizes a week of emails or Slack messages every Monday morning',
-      'Generates a first draft of a proposal or SOW from a few bullet points',
-      'Transcribes voicemails and routes them to the right person',
-    ],
-  },
-  {
-    icon: FiCalendar,
-    title: 'Executive Assistant',
-    tagline: 'Handles the scheduling and coordination you keep putting off.',
-    items: [
-      'Finds a meeting time across multiple calendars and sends the invite',
-      'Reminds you about recurring tasks before you forget them',
-      'Auto-schedules social posts from a content queue',
-      'Tracks recurring deadlines so they don\'t sneak up on you',
+    label: 'Always watching',
+    desc: 'Monitors things so you don't have to.',
+    prompts: [
+      { user: 'If the site goes down, text me immediately.', agent: 'Watching it. You'll get a text within a minute of any downtime.' },
+      { user: 'When a new Google Review comes in, draft a response for me to approve.', agent: 'On it — I'll have a draft ready before you even see the notification.' },
+      { user: 'Keep an eye on the competitor pricing page and let me know if anything changes.', agent: 'I'll check weekly and flag any updates.' },
     ],
   },
 ];
 
-// Stagger card appearance after header
-const CARD_BASE = HEADER_DONE + 200;
-const CARD_GAP  = 120;
+const HEADER_H1  = 300;
+const HEADER_SUB = 650;
+const HEADER_DONE = HEADER_SUB + 22 * 22;
+
+const SECTION_GAP = 280;
 
 export default function Products() {
   return (
     <main className="min-h-screen bg-[#0a0a0a] px-5 sm:px-8 pt-28 pb-24">
-      <div className="max-w-6xl mx-auto">
+      <div className="max-w-4xl mx-auto">
 
         {/* Header */}
-        <div className="mb-14 max-w-2xl">
-          <motion.p {...appear(HEADER_LABEL)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
-            <StreamText speed={45} startDelay={HEADER_LABEL}>01 — Your AI Team</StreamText>
+        <div className="mb-16 max-w-2xl">
+          <motion.p {...appear(0)} className="text-xs font-mono tracking-[0.2em] uppercase mb-3" style={{ color: 'var(--accent)' }}>
+            <StreamText speed={45}>What we build</StreamText>
           </motion.p>
-          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight">
-            <StreamText speed={50} startDelay={HEADER_H1}>Hire by role, not by software.</StreamText>
+          <motion.h1 {...appear(HEADER_H1)} className="text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-tight mb-4">
+            <StreamText speed={48} startDelay={HEADER_H1}>An AI you just talk to.</StreamText>
           </motion.h1>
-          <motion.p {...appear(HEADER_SUB)} className="mt-4 text-gray-500 leading-relaxed">
+          <motion.p {...appear(HEADER_SUB)} className="text-gray-500 leading-relaxed">
             <StreamText speed={22} startDelay={HEADER_SUB}>
-              Each agent handles a specific business function — customer calls, invoicing, lead follow-up, whatever you&apos;re falling behind on. You pick the role. We build and run the agent.
+              On standby around the clock. Reachable through your messaging app. You tell it what to do — once, or on a schedule — and it handles it. One agent or several, it&apos;s up to you.
             </StreamText>
           </motion.p>
         </div>
 
-        {/* Role cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {ROLES.map(({ icon: Icon, title, tagline, items }, idx) => {
-            const cardAt = CARD_BASE + idx * CARD_GAP;
-            const itemBase = cardAt + 300;
-            return (
-              <motion.div
-                key={title}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: cardAt / 1000, duration: 0.4, ease: 'easeOut' }}
-                className="p-6 sm:p-7 rounded-2xl border border-white/8 bg-[#111] hover:border-white/15 transition-colors group cursor-default flex flex-col"
-              >
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-5 group-hover:scale-110 transition-transform flex-shrink-0"
-                  style={{ backgroundColor: 'var(--accent)' }}>
-                  <Icon className="text-[#0a0a0a]" size={18} />
+        {/* Example sections */}
+        {EXAMPLES.map(({ icon: Icon, label, desc, prompts }, sIdx) => {
+          const sectionAt = HEADER_DONE + 300 + sIdx * SECTION_GAP;
+          return (
+            <motion.div
+              key={label}
+              {...appear(sectionAt)}
+              className="mb-12"
+            >
+              {/* Section label */}
+              <div className="flex items-center gap-2.5 mb-5">
+                <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
+                  style={{ backgroundColor: 'rgba(0,255,136,0.12)' }}>
+                  <Icon size={14} style={{ color: 'var(--accent)' }} />
                 </div>
+                <div>
+                  <span className="text-sm font-semibold text-white">{label}</span>
+                  <span className="text-gray-600 text-sm"> — {desc}</span>
+                </div>
+              </div>
 
-                <h2 className="text-lg font-bold text-white mb-1 font-mono">
-                  <StreamText speed={50} startDelay={cardAt + 60}>{title}</StreamText>
-                </h2>
-                <p className="text-sm text-gray-500 leading-relaxed mb-5">
-                  <StreamText speed={24} startDelay={cardAt + 180}>{tagline}</StreamText>
-                </p>
+              {/* Prompt cards */}
+              <div className="space-y-3 pl-0">
+                {prompts.map(({ user, agent }, pIdx) => (
+                  <motion.div
+                    key={pIdx}
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: (sectionAt + 100 + pIdx * 180) / 1000, duration: 0.35, ease: 'easeOut' }}
+                    className="rounded-xl border border-white/8 overflow-hidden"
+                    style={{ background: '#0f0f0f' }}
+                  >
+                    {/* User message */}
+                    <div className="px-5 py-4 flex items-start gap-3 border-b border-white/6">
+                      <div className="w-6 h-6 rounded-full bg-white/10 flex-shrink-0 flex items-center justify-center mt-0.5">
+                        <span className="text-[10px] text-gray-400 font-mono">You</span>
+                      </div>
+                      <p className="text-sm text-gray-300 leading-relaxed">&ldquo;{user}&rdquo;</p>
+                    </div>
+                    {/* Agent reply */}
+                    <div className="px-5 py-4 flex items-start gap-3" style={{ background: 'rgba(0,255,136,0.03)' }}>
+                      <div className="w-6 h-6 rounded-full flex-shrink-0 flex items-center justify-center mt-0.5"
+                        style={{ backgroundColor: 'rgba(0,255,136,0.15)' }}>
+                        <span className="text-[10px] font-mono" style={{ color: 'var(--accent)' }}>AI</span>
+                      </div>
+                      <p className="text-sm text-gray-400 leading-relaxed">{agent}</p>
+                    </div>
+                  </motion.div>
+                ))}
+              </div>
+            </motion.div>
+          );
+        })}
 
-                <ul className="space-y-2.5 mt-auto">
-                  {items.map((item, i) => (
-                    <li key={item} className="flex items-start gap-2 text-xs text-gray-400 leading-snug">
-                      <FiCheck size={11} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 2 }} />
-                      <StreamText speed={30} startDelay={itemBase + i * 220}>{item}</StreamText>
-                    </li>
-                  ))}
-                </ul>
-              </motion.div>
-            );
-          })}
-        </div>
+        {/* Bottom context */}
+        <motion.div {...appear(HEADER_DONE + 300 + EXAMPLES.length * SECTION_GAP + 200)} className="mb-10">
+          <p className="text-gray-600 text-sm leading-relaxed max-w-xl">
+            These are examples — not a fixed menu. Your agent does what you tell it, in the order you tell it, on whatever schedule makes sense for your business. Start with one thing. Add more as you need it.
+          </p>
+        </motion.div>
 
         {/* CTA */}
         <motion.div
-          {...appear(CARD_BASE + ROLES.length * CARD_GAP + 400)}
-          className="mt-12 rounded-2xl border border-white/8 p-8 sm:p-10 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6"
+          {...appear(HEADER_DONE + 300 + EXAMPLES.length * SECTION_GAP + 400)}
+          className="rounded-2xl border border-white/8 p-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6"
           style={{ background: '#0d0d0d' }}
         >
           <div>
-            <p className="text-white font-bold text-xl mb-1">Ready to staff up?</p>
-            <p className="text-gray-500 text-sm max-w-md">
-              Tell us which role would make the biggest difference. We&apos;ll scope it, build it, and keep it running.
-            </p>
+            <p className="text-white font-bold text-xl mb-1">Want to see what it could do for you?</p>
+            <p className="text-gray-500 text-sm">Tell us what you're dealing with. We'll figure out whether an agent makes sense.</p>
           </div>
           <Link
             href="/contact"
             className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-semibold text-[#0a0a0a] whitespace-nowrap transition-all hover:scale-105 active:scale-95 flex-shrink-0"
             style={{ backgroundColor: 'var(--accent)', boxShadow: '0 0 24px rgba(0,255,136,0.2)' }}
           >
-            Build your team <FiArrowRight />
+            Let&apos;s talk <FiArrowRight />
           </Link>
         </motion.div>
 


### PR DESCRIPTION
## What changed

Completely replaced the products page content. Old page sold three technology products (Voice Agent, AI Agents, Local File Search). New page sells six job roles that small business owners can map directly to their pain points.

## Roles

| Role | Function |
|---|---|
| Front Desk Agent | After-hours calls, lead capture, FAQ, appointment reminders |
| Office Manager | Invoicing, financial reports, inbox triage, form-filling |
| Sales Rep | Lead enrichment, pipeline management, drip sequences, cold lead alerts |
| On-Call Monitor | Uptime, competitor intel, Google Reviews, brand mentions |
| Research Assistant | Doc Q&A (RAG), email/Slack summaries, proposal drafts, voicemail routing |
| Executive Assistant | Calendar scheduling, recurring reminders, social post queue |

## Also added

Bottom CTA block: "Ready to staff up?" → contact page

## What's the same

Visual identity is unchanged — dark theme, green accent, Framer Motion animations, StreamText streaming effect, same card layout pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)